### PR TITLE
Adds outputs closer to the simsopt version of the script.

### DIFF
--- a/output_to_gx.py
+++ b/output_to_gx.py
@@ -437,7 +437,7 @@ def output_to_gx(axis, surfaces, iotas, tf, field, s=0.1, alpha=0, npoints=1024,
         plt.figure(figsize=(12, 8))
         nrows = 4
         ncols = 2
-        plot_variables = ['modB_on_fl', 'gradpar_on_fl', ]
+        plot_variables = ['modB_on_fl', 'gradpar_on_fl', 'gradALPHA_dot_B_cross_gradB_on_fl', 'gradALPHA_dot_B_cross_gradB_on_fl', 'gradS_dot_B_cross_gradB_on_fl', 'gradALPHA_dot_gradALPHA_on_fl', 'gradS_dot_gradALPHA_on_fl', 'gradS_dot_gradS_on_fl']
         for j, variable in enumerate(plot_variables):
             plt.subplot(nrows, ncols, j + 1)
             plt.plot(out_dict['varphi_on_fl'], out_dict[variable])

--- a/output_to_gx.py
+++ b/output_to_gx.py
@@ -305,8 +305,7 @@ def output_to_gx(axis, surfaces, iotas, tf, field, s=0.1, alpha=0, npoints=1024,
             s_XYZ[i, j, 2] = InterpolatedUnivariateSpline(tf, XYZ[:, i, j, 2], ext=2, k=k)(s)
             # varphi coordinates on flux surface
             s_VARPHI[i,j] = InterpolatedUnivariateSpline(tf, VARPHI[:,i,j], ext=2, k=k)(s)
-
-
+    
     # evaluate covariate basis functions at points on surface with label s
     dXYZ_dS = np.zeros(XYZ.shape)
     for m in range(dXYZ_dS.shape[0]):
@@ -365,7 +364,8 @@ def output_to_gx(axis, surfaces, iotas, tf, field, s=0.1, alpha=0, npoints=1024,
     gradS      = np.cross(s_dXYZ_dVARPHI, s_dXYZ_dTHETA)/J[:, :, None]
     gradVARPHI = np.cross(s_dXYZ_dTHETA, s_dXYZ_dS)/J[:, :, None]
     gradTHETA = np.cross(s_dXYZ_dS, s_dXYZ_dVARPHI)/J[:, :, None]
-    gradALPHA = gradTHETA - iota * gradVARPHI - s_VARPHI[:, :, None] * gradS * dds_iota
+    # gradALPHA = gradTHETA - iota * gradVARPHI - s_VARPHI[:, :, None] * gradS * dds_iota
+    
     
     gradS_dot_gradTHETA = np.sum(gradS*gradTHETA, axis=-1)
     gradS_dot_gradVARPHI = np.sum(gradS*gradVARPHI, axis=-1)
@@ -376,13 +376,13 @@ def output_to_gx(axis, surfaces, iotas, tf, field, s=0.1, alpha=0, npoints=1024,
     modB = field.set_points(s_XYZ.reshape((-1, 3))).AbsB().reshape(s_XYZ.shape[:-1])
 
     gradpar = -iota * J/modB # \vec{b} \cdot \nabla \theta. equality follows from \vec{B} = \nabla \psi x \nabla \alpha. 
-    gradALPHA_dot_gradALPHA = np.sum(gradALPHA*gradALPHA, axis=-1)
-    gradS_dot_gradALPHA = np.sum(gradS*gradALPHA, axis=-1)
+    # gradALPHA_dot_gradALPHA = np.sum(gradALPHA*gradALPHA, axis=-1)
+    # gradS_dot_gradALPHA = np.sum(gradS*gradALPHA, axis=-1)
 
     # calculate drifts
     B = field.set_points(s_XYZ.reshape((-1, 3))).B().reshape(s_XYZ.shape)
     gradB = field.set_points(s_XYZ.reshape((-1, 3))).GradAbsB().reshape(s_XYZ.shape)
-    gradALPHA_dot_B_cross_gradB = np.sum(gradALPHA * np.cross(B, gradB), axis=-1)
+    # gradALPHA_dot_B_cross_gradB = np.sum(gradALPHA * np.cross(B, gradB), axis=-1)
     gradS_dot_B_cross_gradB = np.sum(gradS * np.cross(B, gradB), axis=-1)
     
     
@@ -395,12 +395,27 @@ def output_to_gx(axis, surfaces, iotas, tf, field, s=0.1, alpha=0, npoints=1024,
     modB_on_fl = fourier_interpolation2(modB, varphi, theta)
     J_on_fl = fourier_interpolation2(J, varphi, theta)
 
+
+    gradALPHA_on_fl = np.zeros((npoints, 3))
+    gradB_on_fl = np.zeros((npoints, 3))
+    B_on_fl = np.zeros((npoints, 3))
+    for i in range(3):
+        gradB_on_fl[:,i] = fourier_interpolation2(gradB[i], varphi, theta)
+        B_on_fl[:,i] = fourier_interpolation2(B[i], varphi, theta)
+        gradVARPHI_on_fl = fourier_interpolation2(gradVARPHI[i], varphi, theta)
+        gradTHETA_on_fl = fourier_interpolation2(gradTHETA[i], varphi, theta)
+        gradS_on_fl = fourier_interpolation2(gradS[i], varphi, theta)
+        gradALPHA_on_fl[:,i] = gradTHETA_on_fl - iota * gradVARPHI_on_fl - dds_iota * varphi * gradS_on_fl
+        
+    gradALPHA_dot_B_cross_gradB_on_fl = np.sum(gradALPHA_on_fl * np.cross(B_on_fl, gradB_on_fl), axis=-1)
+
     gradpar_on_fl = fourier_interpolation2(gradpar, varphi, theta)
-    gradALPHA_dot_gradALPHA_on_fl = fourier_interpolation2(gradALPHA_dot_gradALPHA, varphi, theta)
-    gradS_dot_gradALPHA_on_fl = fourier_interpolation2(gradS_dot_gradALPHA, varphi, theta)
-    gradS_dot_B_cross_gradB_on_fl =  fourier_interpolation2(gradS_dot_B_cross_gradB, varphi, theta)
-    gradALPHA_dot_B_cross_gradB_on_fl =  fourier_interpolation2(gradALPHA_dot_B_cross_gradB, varphi, theta)
-    
+    gradALPHA_dot_gradALPHA_on_fl = gradTHETA_dot_gradTHETA_on_fl + iota**2 * gradVARPHI_dot_gradVARPHI_on_fl \
+        + varphi**2 * dds_iota**2 * gradS_dot_gradS_on_fl \
+        - 2 * (iota * gradTHETA_dot_gradVARPHI_on_fl + varphi * dds_iota * gradS_dot_gradTHETA_on_fl + varphi * dds_iota * iota * gradS_dot_gradVARPHI_on_fl)
+    gradS_dot_gradALPHA_on_fl = gradS_dot_gradTHETA_on_fl - iota * gradS_dot_gradVARPHI_on_fl - varphi * dds_iota * gradS_dot_gradS_on_fl
+
+    gradS_dot_B_cross_gradB_on_fl =  fourier_interpolation2(gradS_dot_B_cross_gradB, varphi, theta) 
     out_dict = {'varphi_on_fl':varphi, 'theta_on_fl':theta,\
                 'gradS_dot_gradTHETA_on_fl':gradS_dot_gradTHETA_on_fl, \
                 'gradS_dot_gradVARPHI_on_fl':gradS_dot_gradVARPHI_on_fl, \


### PR DESCRIPTION
Right now, the outputs do not match their simsopt versions, but I figured it might be useful to push it up anyway to get a second pair of eyes on it. I'm pretty confused about modB not matching, since that should be the easiest thing to get right, and it can't be due to a simple shift in coordinates since that wouldn't get the values of the max and mins wrong?
![0672363](https://github.com/andrewgiuliani/output_to_gx/assets/731405/ffcd4e69-0797-44ce-be13-4ff34419eec2)
![0887713](https://github.com/andrewgiuliani/output_to_gx/assets/731405/bc6f858d-9484-4ff3-81d5-c144cca978d2)

There is also definitely a bug in the line of code:
gradALPHA = gradTHETA - iota * gradVARPHI - s_VARPHI[:, :, None] * gradS * dds_iota
The problem is that s_VARPHI is single valued on the surface, but the varphi we want here should increase past 2pi as we follow the field-line. Unsurprisingly (in hindsight), grad alpha cannot be defined globally on the surface so it must be calculated in another way. This effects how we calculate ∇α², ∇α•∇ψ. I suspect that the effect might cancel out in the ∇α components of the drifts, but I'm not sure. The affected quantities cannot be calculated with fourier 2d interpolation when the global shear (dds_iota = dι/ds) is non-zero. I'll think about this some more tomorrow.